### PR TITLE
Ownership fix

### DIFF
--- a/Sources/RNLibreToolsiOS13/Foundation/Logger/Logger.swift
+++ b/Sources/RNLibreToolsiOS13/Foundation/Logger/Logger.swift
@@ -4,20 +4,32 @@ protocol Logging {
     func error(_ s: String)
     func info(_ s: String)
     func warning(_ s: String)
+    
+    func with(prefix: String) -> Logging
 }
 
 public final class NaiveLogger: Logging {
     
+    private let prefix: String
+    
+    init(prefix: String = "") {
+        self.prefix = prefix
+    }
+    
     func error(_ s: String) {
-        print("[ERR] \(s)")
+        print("[ERR]\(prefix) \(s)")
     }
     
     func info(_ s: String) {
-        print("[INFO] \(s)")
+        print("[INFO]\(prefix) \(s)")
     }
         
     func warning(_ s: String) {
-        print("[WARN] \(s)")
+        print("[WARN]\(prefix) \(s)")
+    }
+    
+    func with(prefix: String) -> Logging {
+        return NaiveLogger(prefix: prefix)
     }
 }
 
@@ -25,4 +37,8 @@ public final class DummyLogger: Logging {
     func error(_ s: String) {}
     func info(_ s: String) {}
     func warning(_ s: String) {}
+    
+    func with(prefix: String) -> Logging {
+        return self
+    }
 }

--- a/Sources/RNLibreToolsiOS13/NFCSensor.swift
+++ b/Sources/RNLibreToolsiOS13/NFCSensor.swift
@@ -1,9 +1,18 @@
 import Foundation
 
-class NFCSensor {
+class NFCSensor: NFCAbstractOperationListener {
+    
+    private var currentOperation: NFCAbstractOperation?
     
     func enque(operation: NFCAbstractOperation) {
         // TODO: consider implementing queue mechanism if needed
-        operation.start()
+        self.currentOperation = operation
+        operation.start(listener: self)
+    }
+    
+    // MARK: - NFCAbstractOperationListener
+    
+    func operationCompleted(_ operation: NFCAbstractOperation) {
+        currentOperation = nil
     }
 }


### PR DESCRIPTION
We didn't hold any strong reference to the operation, so it was deallocated quickly.

1) Now NFCSensor owns operation
2) UUID per operation added for simplified logging
3) We track deinit to both ensure that operation will never be deallocated before the completion and at the same time to track that we don't leak memory